### PR TITLE
Added ignore default link prefixing

### DIFF
--- a/_config/languageprefix.yml
+++ b/_config/languageprefix.yml
@@ -8,6 +8,7 @@ SiteTree:
 Name: languageprefix-config
 ---
 prefixconfig:
-  locale_prefix_map: ''
+  locale_prefix_map:
+  ignore_default_locale: false
   enable_duplicate_urlsegments: false
 

--- a/_config/languageprefix.yml
+++ b/_config/languageprefix.yml
@@ -1,11 +1,11 @@
 ---
-Name: languageprefix-extensions
+Name: languageprefixextensions
 ---
 SiteTree:
   extensions:
     ['LanguagePrefix'] 
 ---
-Name: languageprefix-config
+Name: languageprefixconfig
 ---
 prefixconfig:
   locale_prefix_map:

--- a/code/LanguagePrefix.php
+++ b/code/LanguagePrefix.php
@@ -49,6 +49,13 @@ class LanguagePrefix extends DataExtension {
 	public static $locale_prefix_map;
 
 	/**
+	 * ignore language prefix on the default locale
+	 * 
+	 * @var bool
+	 */
+	public static $ignore_default_locale;
+
+	/**
 	 * return the language prefix for the current locale. If no locale is given,
 	 * the default Translatable locale is assumed. 
 	 * 

--- a/code/LanguagePrefix.php
+++ b/code/LanguagePrefix.php
@@ -153,6 +153,7 @@ class LanguagePrefix extends DataExtension {
 		}
 		return '';	
 	}
+
 	
 	/**
 	 * Add the language prefix to the relative link. Be sure to remove the
@@ -162,13 +163,17 @@ class LanguagePrefix extends DataExtension {
 	 * @param type $action 
 	 */
 	public function updateRelativeLink(&$base, &$action) {
-				
+		
+		if(Config::inst()->get('prefixconfig', 'ignore_default_locale') && 
+			$this->owner->Locale == Translatable::default_locale()) {
+			return;
+		}
+
 		if (empty($action) && !$this->owner->ParentID &&
 			$base == self::get_homepage_link_by_locale($this->owner->Locale)) {
-			
 			$base = null;
 		}
-		
+
 		$prefix = self::get_prefix($this->owner->Locale);
 			
 		if (!preg_match("@^{$prefix}/@i", $base)) {

--- a/code/PrefixModelAsController.php
+++ b/code/PrefixModelAsController.php
@@ -29,9 +29,29 @@ class PrefixModelAsController extends ModelAsController {
 		if (!$prefix = $this->request->param('Prefix')) {
 			$prefix = LanguagePrefix::get_prefix();
 		}
-		
+
 		// No locale means the prefix might be an old URL...
+		// // Or it means that we are ignoring prefixes for this (default) locale
 		if (!$this->setLocale($prefix)) {
+
+			if(Config::inst()->get('prefixconfig', 'ignore_default_locale') {
+				$this->Locale = Translatable::default_locale();
+				$pattern = '$URLSegment//$Action/$ID/$OtherID';
+
+				$request = new SS_HTTPRequest(
+					$this->request->httpMethod(),
+					$this->request->getURL(),
+					$this->request->getVars(),
+					$this->request->postVars(),
+					$this->request->getBody()
+				);
+
+				if($request->match($pattern, true)) {
+					$this->setRequest($request);
+					return parent::getNestedController();
+				}
+
+			}
 
 			$this->Locale = Translatable::default_locale();
 			return $this->showPageNotFound();
@@ -39,7 +59,7 @@ class PrefixModelAsController extends ModelAsController {
 		} else {
 			$URLSegment = $this->request->param('URLSegment');
 		}	
-		
+
 		// Empty URLSegment? Try and get the homepage for the current locale
 		if(empty($URLSegment)) {
 			PrefixRootURLController::set_is_at_root();
@@ -72,7 +92,7 @@ class PrefixModelAsController extends ModelAsController {
 		Translatable::enable_locale_filter();
 		
 		$filter = array('URLSegment' => Convert::raw2sql($URLSegment));
-		if (SiteTree::nested_urls()) $filter['ParentID'] = '0'; 
+		if (Config::inst()->get('SiteTree', 'nested_urls')) $filter['ParentID'] = '0'; 
 		$sitetree = SiteTree::get()->filter($filter)->First();
 			    
 		

--- a/code/PrefixModelAsController.php
+++ b/code/PrefixModelAsController.php
@@ -36,7 +36,7 @@ class PrefixModelAsController extends ModelAsController {
 
 			$this->Locale = Translatable::default_locale();
 
-			if(Config::inst()->get('prefixconfig', 'ignore_default_locale') {
+			if(Config::inst()->get('prefixconfig', 'ignore_default_locale')) {
 				$pattern = '$URLSegment//$Action/$ID/$OtherID';
 
 				$request = new SS_HTTPRequest(

--- a/code/PrefixModelAsController.php
+++ b/code/PrefixModelAsController.php
@@ -34,8 +34,9 @@ class PrefixModelAsController extends ModelAsController {
 		// // Or it means that we are ignoring prefixes for this (default) locale
 		if (!$this->setLocale($prefix)) {
 
+			$this->Locale = Translatable::default_locale();
+
 			if(Config::inst()->get('prefixconfig', 'ignore_default_locale') {
-				$this->Locale = Translatable::default_locale();
 				$pattern = '$URLSegment//$Action/$ID/$OtherID';
 
 				$request = new SS_HTTPRequest(
@@ -53,7 +54,6 @@ class PrefixModelAsController extends ModelAsController {
 
 			}
 
-			$this->Locale = Translatable::default_locale();
 			return $this->showPageNotFound();
 
 		} else {

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -30,7 +30,7 @@ To use custom language prefixes, change the prefixconfig seyttings in your _conf
 
 	:::php
 	---
-	Name: languageprefix-config
+	Name: languageprefixconfig
 	---
 	prefixconfig:
 	  locale_prefix_map:


### PR DESCRIPTION
Ability to have mysite.com/mypage defaulting to mysite.com/en/mypage (or whatever is set as the default locale for Translatable)
