### PR TITLE
Composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,13 @@
 	{
 		"silverstripe/framework": "~3.1",
 		"silverstripe/cms": "~3.1",
-		"silverstripe/translatable": "dev-master"
+		"silverstripe/translatable": "2.0.*"
 	},
 	"support": 
 	{
 		"issues": "https://github.com/Martimiz/silverstripe-languageprefix/issues?state=open"
-	}	
+	},
+	"extra": {
+                "installer-name": "languageprefix"
+        }	
 }


### PR DESCRIPTION
Thanks for a great piece of software!

Installing the module through composer would install it into the folder "silverstripe-languagprefix". With this change, it will now install into "languageprefix" automatically.

Relying on "dev-master" versions is a very bad practice. Explicitly stating what version of translatable that languageprefix is compatible with is allot more reliable.

Sidenote: It would be great if you could start tagging your commits for the same reasons as above. I do not find it very reliable having to specify "dev-master" in order to use this module.
