### PR TITLE
Change default value of locale_prefix_map to an empty array

### DIFF
--- a/_config/languageprefix.yml
+++ b/_config/languageprefix.yml
@@ -8,6 +8,6 @@ SiteTree:
 Name: languageprefix-config
 ---
 prefixconfig:
-  locale_prefix_map: ''
+  locale_prefix_map: []
   enable_duplicate_urlsegments: false
 


### PR DESCRIPTION
We are getting an error when setting locale_prefix_map in site/_config/languageprefix.yml. We found out that the problem is caused by string default value set by languageprefix extension. Silverstripe 3.1.9 raises an exception when trying to merge default string with an array in our config.