### PR TITLE
fix routing for SS 3.2+

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,8 +1,41 @@
 ---
-Name: modelascontrollerroutes
-After: cms/routes#modelascontrollerroutes
+Name: languageprefixroutes
+After: '#modelascontrollerroutes'
 ---
 Director:
-    rules:
-        '': 'PrefixModelAsController'
-        '$URLSegment//$Action/$ID/$OtherID': 'PrefixModelAsController'
+  rules:
+    '': 'PrefixModelAsController'
+    '$URLSegment//$Action/$ID/$OtherID': 'PrefixModelAsController'
+    'StaticExporter//$Action/$ID/$OtherID': 'StaticExporter'
+    'RebuildStaticCacheTask//$Action/$ID/$OtherID': 'RebuildStaticCacheTask'
+    'RemoveOrphanedPagesTask//$Action/$ID/$OtherID': 'RemoveOrphanedPagesTask'
+    'SiteTreeMaintenanceTask//$Action/$ID/$OtherID': 'SiteTreeMaintenanceTask'
+    'SiteTreeMaintenanceTask//$Action/$ID/$OtherID': 'SiteTreeMaintenanceTask'
+---
+Name: lpcoreroutes
+After: '#languageprefixroutes'
+---
+Director:
+  rules:
+    'Security//$Action/$ID/$OtherID': 'Security'
+    'CMSSecurity//$Action/$ID/$OtherID': 'CMSSecurity'
+    'dev': 'DevelopmentAdmin'
+    'interactive': 'SapphireREPL'
+    'InstallerTest//$Action/$ID/$OtherID': 'InstallerTest'
+    'JSTestRunner//$Action/$ID/$OtherID': 'JSTestRunner'
+    'SapphireInfo//$Action/$ID/$OtherID': 'SapphireInfo'
+    'SapphireREPL//$Action/$ID/$OtherID': 'SapphireREPL'
+---
+Name: lpadminroutes
+After: '#languageprefixroutes'
+---
+Director:
+  rules:
+    'admin': 'AdminRootController'
+---
+Name: lplegacycmsroutes
+After: '#languageprefixroutes'
+---
+Director:
+  rules:
+    'admin/cms': '->admin/pages'


### PR DESCRIPTION
Hi @Martimiz, 
I have been struggling to setup the routing for this module using SS 3.4. 
I followed your instructions on https://github.com/Martimiz/silverstripe-languageprefix/blob/master/docs/en/routing.md, but it just didn't quite work. I then updated all the core routes from cms and framework and it seems to work.
Initially I had put the consolidated routes in mysite/_config/routes.yml, but then I thought it might be worthwhile to directly incorporate them in the module itself. Hence this PR.
What was your intention by having the routing in the instructions and not already setup in the code? SS version issues and maintainability, I assume?
Is there a way we can make this more flexible without re-defining all the core routes? And without having to setup the routing for each project manually (again)?
Cheers, Flo
